### PR TITLE
Missing Fontfile in build manifest

### DIFF
--- a/ThreatClassic2.xml
+++ b/ThreatClassic2.xml
@@ -26,6 +26,9 @@
 	<Script file="locale\zhCN.lua"/>
 	<Script file="locale\zhTW.lua"/>
 
+	<!-- Media -->
+	<Script file="media\NotoSans-SemiCondensedBold.ttf"/>
+
 	<!-- Core -->
 	<Script file="core\config.lua"/>
 	<Script file="core\core.lua"/>


### PR DESCRIPTION
Added missing Fontfile NotoSans-SemiCondensedBold.ttf

Related error at PTR:
5/17 18:59:37.842  Streaming failed -- Interface\AddOns\ThreatClassic2\media\NotoSans-SemiCondensedBold.ttf [Invalid file handle]. Errorstack: 
 Can't find file in build manifest